### PR TITLE
cookoff handledamage edit by Dlegion

### DIFF
--- a/addons/cookoff/functions/fnc_handleDamage.sqf
+++ b/addons/cookoff/functions/fnc_handleDamage.sqf
@@ -12,6 +12,19 @@
  * _this call ace_cookoff_fnc_handleDamage
  *
  * Public: No
+ * PROPOSED EDIT BY DLEGION :
+ * please be patient i'm a poor noob about code, i hardly understand it,
+ * and there are sure better ways to get the same/better results,
+ * i just do my best to get the desired results, and all the changes i will submit are tested,
+ * and to my knowledge they work good with no problems / bugs.
+ * thanks for your time spent on my suggestions.
+ * COOKOFF SPEFIC EDIT INFO:
+ * the problem with 3.7.0 version: Leopard AAF tank seems to be unkillable (not exploding) by Comanche DAGR and cannon,
+ * by kajman AG missiles and cannon, and with titan AT rockets sometimes blow up with 1 hit, sometimes need 4 hits.
+ * the solution : as temporary fix i found that changing some numbers and removing a couple of lines, 
+ * now the Comanche DAGR and cannon, kajman AG missiles and 30mm cannon with AP rounds (and only AP rounds, HE don't harm it)
+ * shot in the turret destroy the tank by cooking it off as they should. 
+ * titan too seems to works correctly. only from some angles it dont kill it in 1 shot, but that's ok for me! 
  */
 #include "script_component.hpp"
 
@@ -49,7 +62,7 @@ if (_simulationType == "car") exitWith {
     if (_hitpoint in ["hithull", "hitfuel", "#structural"] && {!IS_EXPLOSIVE_AMMO(_ammo)}) then {
         _damage min 0.89
     } else {
-        if (_hitpoint isEqualTo "hitengine" && {_damage > 0.9}) then {
+        if (_hitpoint isEqualTo "hitengine" && {_damage > 0.8}) then {
             _vehicle call FUNC(engineFire);
         };
         _damage
@@ -60,17 +73,13 @@ if (_simulationType == "tank") exitWith {
     // determine ammo storage location
     private _ammoLocationHitpoint = getText (_vehicle  call CBA_fnc_getObjectConfig >> QGVAR(ammoLocation));
 
-    if (_hitIndex in (GVAR(cacheTankDuplicates) getVariable (typeOf _vehicle))) then {
-        _hitpoint = "#subturret";
-    };
-    
     // ammo was hit, high chance for cook-off
     if (_hitpoint == _ammoLocationHitpoint) then {
-        if (_damage > 0.5 && {random 1 < 0.7}) then {
+        if (_damage > 0.5 && {random 1 < 1.7}) then {
             _vehicle call FUNC(cookOff);
         };
     } else {
-        if (_hitpoint in ["hithull", "hitturret", "#structural"] && {_newDamage > 0.6 + random 0.3}) then {
+        if (_hitpoint in ["hitbody", "hitturret", "#structural"] && {_newDamage > 0.5 + random 0.3}) then {
             _vehicle call FUNC(cookOff);
         };
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Describe what this pull request will do
- Each change in a separate line
- Include documentation if applicable
- Respect the [Development Guidelines](http://ace3mod.com/wiki/development/)

PROPOSED EDIT BY DLEGION :
- please be patient i'm a poor noob about code, i hardly understand it,
- and there are sure better ways to get the same/better results,
- i just do my best to get the desired results, and all the changes i will submit are tested,
- and to my knowledge they work good with no problems / bugs.
- thanks for your time spent on my suggestions.
- COOKOFF SPEFIC EDIT INFO:
- the problem with 3.7.0 version: Leopard AAF tank seems to be unkillable (not exploding) by Comanche DAGR and cannon,
- by kajman AG missiles and cannon, and with titan AT rockets sometimes blow up with 1 hit, sometimes need 4 hits.
- the solution : as temporary fix i found that changing some numbers and removing a couple of lines, 
- now the Comanche DAGR and cannon, kajman AG missiles and 30mm cannon with AP rounds (and only AP rounds, HE don't harm it)
- shot in the turret destroy the tank by cooking it off as they should. 
- titan too seems to works correctly. only from some angles it dont kill it in 1 shot, but that's ok for me!
